### PR TITLE
gcc/clang deterministic in and out of Nix

### DIFF
--- a/basil/planter.nix
+++ b/basil/planter.nix
@@ -39,10 +39,15 @@ let
         fi
       done
 
+      export NIX_HARDENING_ENABLE=
+      export NIX_LDFLAGS=
+      export NIX_CFLAGS=
+      export NIX_CFLAGS_COMPILE=
+
       if [[ -z "''${NIX_STORE:-}" ]]; then
-        export NIX_BUILD_TOP=$(pwd)
-        export NIX_STORE=/nix/store
         export NIX_ENFORCE_PURITY=1
+        export NIX_STORE=/nix/store
+        export NIX_BUILD_TOP=$(pwd)
       fi
 
       if [[ ''${#args[@]} != 5 ]]; then
@@ -84,10 +89,6 @@ buildEnv {
       ''
         trap 'set +x' EXIT
         set -x
-
-        export NIX_HARDENING_ENABLE=
-        export NIX_LDFLAGS="''${NIX_LDFLAGS/-rpath $out\/lib/}"
-        env
 
         mkdir $out && cd $out
         echo 'int main(void){return 3;}' > a.c

--- a/basil/planter.nix
+++ b/basil/planter.nix
@@ -27,7 +27,8 @@ let
         --unset NIX_CFLAGS \
         --unset NIX_CFLAGS_COMPILE \
         --set NIX_ENFORCE_PURITY 1 \
-        --set NIX_STORE $NIX_STORE
+        --set NIX_STORE $NIX_STORE \
+        --prefix PATH : ${pkg}/bin
     '';
   };
   planter-ccs = builtins.map wrap-nix-cc [ gcc-aarch64 clang-aarch64 ];

--- a/basil/planter.nix
+++ b/basil/planter.nix
@@ -77,6 +77,7 @@ let
       ${gcc-aarch64.targetPrefix}"$compiler" ''${CFLAGS:-} "$in" -o "$out"
       ddisasm-deterministic "$out" --ir "$gtirb"
       gtirb-semantics "$gtirb" "$gts"
+      proto-json.py "$gts" "$gts" --idem
     '';
   };
 in


### PR DESCRIPTION
this has the small side-effect of making them ineffective general-purpose compilers. flags such as -L/usr/lib will be silently dropped since they don't live inside the /nix/store. this is maybe ok for now but we can revisit this later.