### PR TITLE
basil: add shell and docker for tools

### DIFF
--- a/basil-shell.nix
+++ b/basil-shell.nix
@@ -1,0 +1,32 @@
+{ mkShell
+, gcc-aarch64
+, clang-aarch64
+, asli
+, ddisasm
+, gtirb-pprinter
+, gtirb-semantics
+}:
+let
+  packages = [
+    gcc-aarch64
+    clang-aarch64
+    asli
+    ddisasm
+    gtirb-pprinter
+    gtirb-semantics
+  ];
+in mkShell {
+  inherit packages;
+  inputsFrom = [ ];
+  shellHook = ''
+    echo
+    echo == pac-nix/BASIL tool shell ==
+    echo
+    echo 'with packages installed:'
+    printf ' - %s\n' ${toString (map (x: x.name) packages)}
+    echo
+  '';
+  meta = {
+    description = "shell containing tools used in the BASIL pipeline"; 
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,8 +65,9 @@
           let drvs = onlyDerivations legacyPackages;
           in drvs // { all = makeAll pkgs drvs; });
 
-      devShells = forAllSystems (pkgs: {
+      devShells = forAllSystems' ({ legacyPackages, pkgs, ... }: {
         ocaml = pkgs.callPackage ./ocaml-shell.nix { };
+        basil-tools = legacyPackages.basil-tools-shell;
         update = pkgs.callPackage ./update-shell.nix { };
       });
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -6,6 +6,13 @@ let
 
       update = prev.callPackage ./update.nix { };
 
+      basil-tools-shell = prev.callPackage ./basil-shell.nix { };
+      basil-tools-docker = prev.dockerTools.streamNixShellImage {
+        name = "basil-tools-docker";
+        tag = "latest";
+        drv = final.basil-tools-shell;
+      };
+
       ocamlPackages_pac = final.ocaml-ng.ocamlPackages_4_14.overrideScope final.overlay_ocamlPackages
         // { _overlay = final.overlay_ocamlPackages; };
       ocamlPackages_pac_5 = final.ocamlPackages.overrideScope final.overlay_ocamlPackages


### PR DESCRIPTION
at the moment, this only contains the tools accompanying BASIL. it is simple to extend to a BASIL dev environment and then to BASIL itself.