### PR TITLE
Ddisasm det fork

### DIFF
--- a/basil/planter.nix
+++ b/basil/planter.nix
@@ -76,7 +76,7 @@ let
       gts="''${args[4]}"
 
       ${gcc-aarch64.targetPrefix}"$compiler" ''${CFLAGS:-} "$in" -o "$out"
-      ddisasm-deterministic "$out" --ir "$gtirb"
+      ddisasm "$out" --ir "$gtirb"
       proto-json.py "$gtirb" "$gtirb" -s8 --idem
       gtirb-semantics "$gtirb" "$gts"
       proto-json.py "$gts" "$gts" --idem

--- a/gtirb/capstone-grammatech.nix
+++ b/gtirb/capstone-grammatech.nix
@@ -6,12 +6,13 @@
 
 capstone.overrideAttrs {
   pname = "capstone-grammatech";
+  version = "5.0.1-unstable-2024-04-30";
 
   src = fetchFromGitHub {
     owner = "GrammaTech";
     repo = "capstone";
-    rev = "a11159a0bbd680e134c53d6a16e304b53488824b";
-    hash = "sha256-0aCmlXsrdWYlxqzRlXj8TNkD0s8xHMTq0YlVJ+t1fD4=";
+    rev = "30a4ecf01b43abed8527d0d84c1ea182e6e3da8b";
+    hash = "sha256-JWw+S2IIBxTxDrdBlu3OqiMZ13y0T1bC2jpUDC3Mn5M=";
   };
 
   preConfigure = ''

--- a/gtirb/gtirb-pprinter.nix
+++ b/gtirb/gtirb-pprinter.nix
@@ -13,23 +13,26 @@
 
 stdenv.mkDerivation {
   pname = "gtirb-pprinter";
-  version = "2.1.0";
+  version = "2.2.0-unstable-2024-10-09";
 
   src = fetchFromGitHub {
     owner = "GrammaTech";
     repo = "gtirb-pprinter";
-    rev = "v2.1.0";
-    hash = "sha256-zgYq6FKxaJ6vLzvOTCfOU4ZUyXvMuFc3abNrqg8NADc=";
+    rev = "762a287f3d12c6aac3d3d000cdc8bf20f5ee34f2";
+    hash = "sha256-9CZ+ndHX5f4rKbGXvCrqEg55Ep9JEkS/u//grdqTpTc=";
   };
 
   buildInputs = [ cmake python3 gtirb boost abseil-cpp gtest ];
   nativeBuildInputs = [ capstone-grammatech ];
 
   cmakeFlags = [ "-DGTIRB_PPRINTER_ENABLE_TESTS=OFF" ];
-
-  preConfigure = ''
-    export CXXFLAGS='-includecstdint -includeset -Wno-error=unused-result -Wno-error=deprecated-declarations -Wno-error=array-bounds'
-  '';
+  CXXFLAGS= [
+    "-includecstdint" 
+    "-includeset"
+    "-Wno-error=unused-result"
+    "-Wno-error=deprecated-declarations"
+    "-Wno-error=array-bounds"
+  ];
 
   meta = {
     homepage = "https://github.com/grammatech/gtirb-pprinter";

--- a/gtirb/gtirb.nix
+++ b/gtirb/gtirb.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchurl
 , fetchFromGitHub
 , cmake
 , python3
@@ -18,6 +19,13 @@ stdenv.mkDerivation {
     rev = "v2.2.0";
     hash = "sha256-dzkVwQ7MvVm4KUX/Lo03yd1P9OHj+q1/kp4ZpdO8NDk=";
   };
+
+  patches = [
+    (fetchurl {
+      url = "https://github.com/rina-forks/gtirb/compare/master..det.patch";
+      hash = "sha256-86cRmnV5CL5DjOzFj+cJYUYKQpHQ6DsqnZDaMGa/kog=";
+    })
+  ];
 
   nativeBuildInputs = [ ];
   buildInputs = [ cmake python3 boost doxygen ];

--- a/gtirb/gtirb.nix
+++ b/gtirb/gtirb.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "gtirb";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "GrammaTech";
     repo = "gtirb";
-    rev = "v2.0.0";
-    hash = "sha256-ueoqxm6iXv4JgzR/xkImT+O8xx+7bA2upx1TJ828LLA=";
+    rev = "v2.2.0";
+    hash = "sha256-dzkVwQ7MvVm4KUX/Lo03yd1P9OHj+q1/kp4ZpdO8NDk=";
   };
 
   nativeBuildInputs = [ ];


### PR DESCRIPTION
We patch gtirb (https://github.com/rina-forks/gtirb/compare/master..det) to use a seeded generator for its UUIDs. Hopefully this will not cause any problems. Ddisasm is patched in a minor way as well.