### PR TITLE
alive2-regehr: 0-unstable-2024-12-25 -> 0-unstable-2025-01-10

### DIFF
--- a/llvm-translator/alive2-aslp.nix
+++ b/llvm-translator/alive2-aslp.nix
@@ -1,5 +1,5 @@
 { lib
-, alive2-regehr
+, alive2-aslp
 , llvmPackages
 , fetchFromGitHub
 , aslp-cpp
@@ -8,10 +8,10 @@
 , perlPackages
 , makeWrapper
 , runCommand
-, alive2-aslp
+, alive2
 }:
 
-(alive2-regehr.override { inherit llvmPackages; }).overrideAttrs (prev: {
+(alive2.override { inherit llvmPackages; }).overrideAttrs (prev: {
   pname = "alive2-aslp";
   version = "0-unstable-2024-12-26";
 
@@ -24,6 +24,8 @@
     rev = "6fcd5a09eeb5aceab368910c3c8fd68339d14a11";
     hash = "sha256-p17JsM6IJeaX35QLo8tXKmAVqtaWblxiMmS2ZM14Tqo=";
   };
+
+  patches = [ ];  # undoing patch needed for upstream alive2
 
   CXXFLAGS = (prev.CXXFLAGS or "") + " -Wno-error=deprecated-declarations";
 

--- a/llvm-translator/alive2-regehr.nix
+++ b/llvm-translator/alive2-regehr.nix
@@ -1,22 +1,19 @@
 { lib
-, alive2
+, alive2-aslp
 , stdenv
 , llvmPackages
 , fetchFromGitHub
 }:
 
-(alive2.override { inherit llvmPackages; }).overrideAttrs (prev: {
+(alive2-aslp.override { inherit llvmPackages; }).overrideAttrs (prev: {
   pname = "alive2-regehr";
-  version = "0-unstable-2024-12-25";
+  version = "0-unstable-2025-01-10";
 
   src = fetchFromGitHub {
     owner = "regehr";
     repo = "alive2";
-    rev = "2728ecaafd0572174150652f9910b73b778c2c1e";
-    hash = "sha256-OQw0GYw0PNYtb/d9ZQfHVAhuxi1k6IQJs/pY8IHBxac=";
+    rev = "a5642ad047a69dcf318a8c4396dc68f668b5d0a1";
+    hash = "sha256-qW1w/M0pfHwRupd1J+PHe1rzEc+9kkXSuOyHmsBPgrE=";
   };
 
-  patches = [ ];
-  CXXFLAGS = (prev.CXXFLAGS or "")
-    + lib.optionalString (!stdenv.isDarwin) " -Wno-error=maybe-uninitialized";
 })


### PR DESCRIPTION
rewrites alive2-regehr to be in terms of alive2-aslp, after the aslp features have been merged into regehr's branch