### PR TITLE
mill-derivation: set MILL_DOWNLOAD_PATH instead of XDG_CACHE_HOME

### DIFF
--- a/mill-derivation/lib/sbt-derivation.nix
+++ b/mill-derivation/lib/sbt-derivation.nix
@@ -46,7 +46,7 @@
       patchShebangs ./mill
     fi
 
-    export XDG_CACHE_HOME=$SBT_DEPS/project/.cache
+    export MILL_DOWNLOAD_PATH=$SBT_DEPS/project/.cache/mill/download
 
     echo "" >> .mill-jvm-opts
     echo "-Divy.home=$SBT_DEPS/project/.ivy" >> .mill-jvm-opts


### PR DESCRIPTION
it's a bit more precise and will prevent extra stuff being put into the dependencies output