### PR TITLE
fixed godbolt-docker-compose.yml config

### DIFF
--- a/basil/godbolt-docker-compose.yml
+++ b/basil/godbolt-docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.20"
 name: basil-godbolt
 
 services:

--- a/basil/godbolt-docker-compose.yml
+++ b/basil/godbolt-docker-compose.yml
@@ -5,7 +5,8 @@ services:
   godbolt:
     image: ghcr.io/uq-pac/basil-godbolt-docker
     restart: always
-    ports: "10240:10240"
+    ports:
+      - "10240:10240"
     environment:
       GTIRB_SEM_SOCKET: "/run/gts/aslp_rpc_socket"
     volumes:


### PR DESCRIPTION
1、/nix/store/admif63da15kqrg32p9q1sfvr13imh0b-start-godbolt/bin/start-godbolt: skipping image load due to matching hash in /tmp/start-godbolt/hash
+ exec docker compose -f /nix/store/nmgsva0dwdw3cbz7a3yi4rmgc63rm45m-godbolt-docker-compose.yml up
validating /nix/store/nmgsva0dwdw3cbz7a3yi4rmgc63rm45m-godbolt-docker-compose.yml: services.godbolt.ports must be a list

2、WARN[0000] /nix/store/rwdqr00a41nlmqgdiddla1pl52mvbpag-godbolt-docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 