### PR TITLE
ci: rollback to macos-14 for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04, macos-14]
         # end-user packages to ci build for cache
         pkg:
           [aslp, bap-aslp, bap-primus, basil,


### PR DESCRIPTION
problems installing nix due to user ids