### PR TITLE
bnfc-treesitter: 0-unstable-2026-02-23 -> 2.9.6.3-unstable-2026-05-08

### DIFF
--- a/bincaml/bnfc-treesitter.nix
+++ b/bincaml/bnfc-treesitter.nix
@@ -7,12 +7,12 @@
 lib.pipe haskellPackages.BNFC [
   (haskell.lib.compose.overrideSrc {
     src = fetchFromGitHub {
-      owner = "rina-forks";
+      owner = "BNFC";
       repo = "bnfc";
-      rev = "6c3bbc2ec0710fcc9f122ec4303c2cdf46ce33c4";
-      hash = "sha256-R4owoA3NKQIGk6RI5A10KlkIFOEna+rRQ0Ir4WHZVYE=";
+      rev = "2e4c906d99d904ba0a214ebd29ddfa95e5a74944";
+      hash = "sha256-7XPTUmdmoWM22UHdDSQSkHP8op6OZSU1a/VGy0czo+0=";
     };
-    version = "0-unstable-2026-02-23";
+    version = "2.9.6.3-unstable-2026-05-08";
   })
   (haskell.lib.compose.overrideCabal (_: {
     postPatch = "cd source";

--- a/update.py
+++ b/update.py
@@ -97,7 +97,7 @@ PACKAGES: list[Package] = [
   Package('aslp-server', 'UQ-PAC/aslp-rpc'),
   Package('aslp-cpp', 'UQ-PAC/aslp-rpc'),
   Package('aslp_client_server_ocaml', 'UQ-PAC/aslp-rpc'),
-  Package('bnfc-treesitter', 'rina-forks/bnfc', 'matches-empty-merge', extra_args=['--override-filename', 'overlay.nix']),
+  Package('bnfc-treesitter', 'bnfc/bnfc', 'master', extra_args=['--override-filename', 'bincaml/bnfc-treesitter.nix']),
   Package('compiler-explorer', 'rina-forks/compiler-explorer', 'basil-new'), # XXX: not in ci!
 ]
 # NOTE: also change files in ./.github/workflows/*.yml


### PR DESCRIPTION
Diff: https://github.com/BNFC/bnfc/compare/6c3bbc2ec0710fcc9f122ec4303c2cdf46ce33c4...2e4c906d99d904ba0a214ebd29ddfa95e5a74944